### PR TITLE
Add support for IHttpClientFactory depenedency injection

### DIFF
--- a/dotNETLemmy.API/LemmyHttpClient.cs
+++ b/dotNETLemmy.API/LemmyHttpClient.cs
@@ -14,8 +14,7 @@ public sealed class LemmyHttpClient : ILemmyHttpClient
     private class LemmyHttpClientException : HttpRequestException {}
     
     public string BaseAddress { get; set; } = string.Empty;
-    private HttpClient? Client { get; }
-    private IHttpClientFactory? HttpClientFactory { get; }
+    private HttpClient Client { get; }
     
     /// <summary>
     ///     Initializes a new instance of the <see cref="LemmyHttpClient" /> class
@@ -32,13 +31,8 @@ public sealed class LemmyHttpClient : ILemmyHttpClient
     public async Task<TResponse> SendAsync<TResponse>(IForm form, CancellationToken cancellationToken = default)
         where TResponse : Response, new()
     {
-        if ((Client ?? HttpClientFactory?.CreateClient()) is not { } client)
-        {
-            throw new LemmyHttpClientException();
-        }
-        
         var req = form.ToRequest(BaseAddress);
-        var res = await client.SendAsync(req, cancellationToken);
+        var res = await Client.SendAsync(req, cancellationToken);
         return await Response.FromHttpResponseMessage<TResponse>(res);
     }
     

--- a/dotNETLemmy.API/LemmyHttpClient.cs
+++ b/dotNETLemmy.API/LemmyHttpClient.cs
@@ -9,31 +9,20 @@ namespace dotNETLemmy.API;
 ///     Helps build Lemmy HTTP Requests.
 /// </summary>
 /// <seealso cref="IDisposable" />
-public class LemmyHttpClient : IDisposable
+public class LemmyHttpClient
 {
-    private bool _disposed; // = false
-
+    private HttpClient Client { get; }
+    
     /// <summary>
     ///     Initializes a new instance of the <see cref="LemmyHttpClient" /> class
+    ///     <para>
+    ///         Intended to be used as an <see cref="IHttpClientFactory"/> typed client
+    ///     </para>
     /// </summary>
-    /// <param name="baseUri">Base uri to the lemmy instance</param>
-    public LemmyHttpClient(Uri baseUri)
+    /// <param name="client">Base uri to the lemmy instance</param>
+    public LemmyHttpClient(HttpClient client)
     {
-        Client = new HttpClient
-        {
-            BaseAddress = baseUri
-        };
-    }
-
-    private HttpClient Client { get; }
-
-    /// <summary>
-    ///     Disposes this instance
-    /// </summary>
-    public void Dispose()
-    {
-        Dispose(true);
-        GC.SuppressFinalize(this);
+        Client = client;
     }
 
     /// <summary>
@@ -920,14 +909,4 @@ public class LemmyHttpClient : IDisposable
     /// </returns>
     public Task<VerifyEmailResponse> VerifyEmail(VerifyEmailForm form, CancellationToken cancellationToken = default) =>
         SendAsync<VerifyEmailResponse>(form, cancellationToken);
-    
-    private void Dispose(bool disposing)
-    {
-        if (_disposed) return;
-        if (disposing)
-            Client.Dispose();
-        _disposed = true;
-    }
-
-    ~LemmyHttpClient() { Dispose(false); }
 }

--- a/dotNETLemmy.API/LemmyHttpClient.cs
+++ b/dotNETLemmy.API/LemmyHttpClient.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using dotNETLemmy.API.Types;
 using dotNETLemmy.API.Types.Forms;
 using dotNETLemmy.API.Types.Responses;
@@ -9,7 +8,8 @@ namespace dotNETLemmy.API;
 ///     Helps build Lemmy HTTP Requests.
 /// </summary>
 /// <seealso cref="IDisposable" />
-public class LemmyHttpClient
+/// <inheritdoc/>
+public class LemmyHttpClient : ILemmyHttpClient
 {
     private HttpClient Client { get; }
     
@@ -24,18 +24,7 @@ public class LemmyHttpClient
     {
         Client = client;
     }
-
-    /// <summary>
-    ///     Sends an asynchronous HTTP request and returns the deserialized response.
-    ///     <para>
-    ///         Avoid calling directly unless the Lemmy instance requires non-standard API calls.
-    ///     </para>
-    /// </summary>
-    /// <typeparam name="TResponse">Deserialized response format, inherits <see cref="Response" /></typeparam>
-    /// <param name="form">The form data to be sent, inherits <see cref="IForm" /></param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>The deserialized response format</returns>
-    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    
     public async Task<TResponse> SendAsync<TResponse>(IForm form, CancellationToken cancellationToken = default)
         where TResponse : Response, new()
     {
@@ -43,870 +32,238 @@ public class LemmyHttpClient
         var res = await Client.SendAsync(req, cancellationToken);
         return await Response.FromHttpResponseMessage<TResponse>(res);
     }
-
-    /// <summary>
-    ///     Adds an administrator.
-    /// </summary>
-    /// <param name="form">The form to send for adding an administrator.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after adding an
-    ///     administrator.
-    /// </returns>
+    
     public Task<AddAdminResponse> AddAdmin(AddAdminForm form, CancellationToken cancellationToken = default) =>
         SendAsync<AddAdminResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Adds a moderator to a community.
-    /// </summary>
-    /// <param name="form">The form to send for adding a moderator to a community. </param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after adding a
-    ///     moderator to a community.
-    /// </returns>
+    
     public Task<AddModToCommunityResponse> AddModToCommunity(AddModToCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<AddModToCommunityResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Approves a registration application.
-    /// </summary>
-    /// <param name="form">The form to send for approving a registration application.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after approving
-    ///     a registration application.
-    /// </returns>
+    
     public Task<ApproveRegistrationApplicationResponse> ApproveRegistrationApplication(ApproveRegistrationApplicationForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ApproveRegistrationApplicationResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Bans a person from a community.
-    /// </summary>
-    /// <param name="form">The form to send for banning a person from a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after banning a
-    ///     person from a community.
-    /// </returns>
+    
     public Task<BanFromCommunityResponse> BanFromCommunity(BanFromCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<BanFromCommunityResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Bans a person.
-    /// </summary>
-    /// <param name="form">The form to send for banning a person.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after banning a
-    ///     person.
-    /// </returns>
+    
     public Task<BanPersonResponse> BanPerson(BanPersonForm form, CancellationToken cancellationToken = default) =>
         SendAsync<BanPersonResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Blocks a community.
-    /// </summary>
-    /// <param name="form">The form to send for blocking a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after blocking
-    ///     a community.
-    /// </returns>
+    
     public Task<BlockCommunityResponse> BlockCommunity(BlockCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<BlockCommunityResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Blocks a person.
-    /// </summary>
-    /// <param name="form">The form to send for blocking a person.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after blocking
-    ///     a person.
-    /// </returns>
+    
     public Task<BlockPersonResponse> BlockPerson(BlockPersonForm form, CancellationToken cancellationToken = default) =>
         SendAsync<BlockPersonResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Changes the password for the current user.
-    /// </summary>
-    /// <param name="form">The form to send for changing the password.></param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after changing
-    ///     the password. <see cref="LoginResponse" />
-    /// </returns>
+    
     public Task<LoginResponse> ChangePassword(ChangePasswordForm form, CancellationToken cancellationToken = default) =>
         SendAsync<LoginResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new comment.
-    /// </summary>
-    /// <param name="form">The form to send for creating a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a comment. <see cref="CommentResponse" />
-    /// </returns>
+    
     public Task<CommentResponse> CreateComment(CreateCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new community.
-    /// </summary>
-    /// <param name="form">The form to send for creating a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a community.
-    /// </returns>
+    
     public Task<CommunityResponse> CreateCommunity(CreateCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommunityResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new post.
-    /// </summary>
-    /// <param name="form">The form to send for creating a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a post.
-    /// </returns>
+    
     public Task<PostResponse> CreatePost(CreatePostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new report for a post.
-    /// </summary>
-    /// <param name="form">The form to send for creating a post report.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a post report.
-    /// </returns>
+    
     public Task<PostReportResponse> CreatePostReport(CreatePostReportForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostReportResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new private message.
-    /// </summary>
-    /// <param name="form">The form to send for creating a private message.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a private message.
-    /// </returns>
+    
     public Task<PrivateMessageResponse> CreatePrivateMessage(CreatePrivateMessageForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessageResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new report for a private message.
-    /// </summary>
-    /// <param name="form">The form to send for creating a private message report. </param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a private message report.
-    /// </returns>
+    
     public Task<PrivateMessageReportResponse> CreatePrivateMessageReport(CreatePrivateMessageReportForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessageReportResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Creates a new report for a private message.
-    /// </summary>
-    /// <param name="form">The form to send for creating a private message report. </param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after creating
-    ///     a private message report.
-    /// </returns>
+    
     public Task<SiteResponse> CreateSite(CreateSiteForm form, CancellationToken cancellationToken = default) =>
         SendAsync<SiteResponse>(form, cancellationToken);
-
-    /// <summary>
-    ///     Deletes a user account.
-    /// </summary>
-    /// <param name="form">The form to send for deleting a user account.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    ///     The task object representing the asynchronous operation. The task result contains the response after deleting
-    ///     a user account.
-    /// </returns>
+    
     public Task<DeleteAccountResponse> DeleteAccount(DeleteAccountForm form, CancellationToken cancellationToken = default) =>
         SendAsync<DeleteAccountResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Deletes a comment.
-    /// </summary>
-    /// <param name="form">The form to send for deleting a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after deleting the comment.
-    /// </returns>
+    
     public Task<CommentResponse> DeleteComment(DeleteCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Deletes a community.
-    /// </summary>
-    /// <param name="form">The form to send for deleting a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after deleting the community.
-    /// </returns>
+    
     public Task<CommunityResponse> DeleteCommunity(DeleteCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommunityResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Deletes a post.
-    /// </summary>
-    /// <param name="form">The form to send for deleting a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after deleting the post.
-    /// </returns>
+    
     public Task<PostResponse> DeletePost(DeletePostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Deletes a private message.
-    /// </summary>
-    /// <param name="form">The form to send for deleting a private message.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after deleting the private message.
-    /// </returns>
+    
     public Task<PrivateMessageResponse> DeletePrivateMessage(DeletePrivateMessageForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessageResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Edits a comment.
-    /// </summary>
-    /// <param name="form">The form to send for editing a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after editing the comment.
-    /// </returns>
+    
     public Task<CommentResponse> EditComment(EditCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Edits a community.
-    /// </summary>
-    /// <param name="form">The form to send for editing a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after editing the community.
-    /// </returns>
+    
     public Task<CommunityResponse> EditCommunity(EditCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommunityResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Edits a post.
-    /// </summary>
-    /// <param name="form">The form to send for editing a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after editing the post.
-    /// </returns>
+    
     public Task<PostResponse> EditPost(EditPostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Edits a private message.
-    /// </summary>
-    /// <param name="form">The form to send for editing a private message.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after editing the private message.
-    /// </returns>
     public Task<PrivateMessageResponse> EditPrivateMessage(EditPrivateMessageForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessageResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Edits a site.
-    /// </summary>
-    /// <param name="form">The form to send for editing a site.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after editing the site.
-    /// </returns>
     public Task<SiteResponse> EditSite(EditSiteForm form, CancellationToken cancellationToken = default) =>
         SendAsync<SiteResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Features a post.
-    /// </summary>
-    /// <param name="form">The form to send for featuring a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after featuring the post.
-    /// </returns>
     public Task<PostResponse> FeaturePost(FeaturePostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Follows a community.
-    /// </summary>
-    /// <param name="form">The form to send for following a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after following the community.
-    /// </returns>
     public Task<CommunityResponse> FollowCommunity(FollowCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommunityResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets the list of banned persons.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the list of banned persons.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the list of banned persons.
-    /// </returns>
     public Task<BannedPersonsResponse> GetBannedPersons(GetBannedPersonsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<BannedPersonsResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets a captcha.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving a captcha.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved captcha.
-    /// </returns>
     public Task<GetCaptchaResponse> GetCaptcha(GetCaptchaForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetCaptchaResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets comments.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving comments.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved comments.
-    /// </returns>
     public Task<GetCommentsResponse> GetComments(GetCommentsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetCommentsResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets a community.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved community.
-    /// </returns>
     public Task<GetCommunityResponse> GetCommunity(GetCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetCommunityResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets the modlog.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the modlog.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved modlog.
-    /// </returns>
     public Task<GetModlogResponse> GetModlog(GetModlogForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetModlogResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets the details of a person.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the person details.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved person details.
-    /// </returns>
     public Task<GetPersonDetailsResponse> GetPersonDetails(GetPersonDetailsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetPersonDetailsResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets mentions of a person.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the person mentions.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved person mentions.
-    /// </returns>
     public Task<GetPersonMentionsResponse> GetPersonMentions(GetPersonMentionsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetPersonMentionsResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets a post.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved post.
-    /// </returns>
     public Task<GetPostResponse> GetPost(GetPostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetPostResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets posts.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving posts.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved posts.
-    /// </returns>
     public Task<GetPostsResponse> GetPosts(GetPostsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetPostsResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets private messages.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving private messages.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved private messages.
-    /// </returns>
     public Task<PrivateMessagesResponse> GetPrivateMessages(GetPrivateMessagesForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessagesResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets replies.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving replies.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved replies.
-    /// </returns>
     public Task<GetRepliesResponse> GetReplies(GetRepliesForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetRepliesResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets the count of reports.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the report count.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved report count.
-    /// </returns>
     public Task<GetReportCountResponse> GetReportCount(GetReportCountForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetReportCountResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets a site.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving a site.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved site.
-    /// </returns>
     public Task<GetSiteResponse> GetSite(GetSiteForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetSiteResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets site metadata.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving site metadata.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved site metadata.
-    /// </returns>
     public Task<GetSiteMetadataResponse> GetSiteMetadata(GetSiteMetadataForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetSiteMetadataResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets the count of unread messages.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the unread count.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved unread count.
-    /// </returns>
     public Task<GetUnreadCountResponse> GetUnreadCount(GetUnreadCountForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetUnreadCountResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Gets the count of unread registration applications.
-    /// </summary>
-    /// <param name="form">The form to send for retrieving the unread registration application count.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved unread registration application count.
-    /// </returns>
     public Task<GetUnreadRegistrationApplicationCountResponse> GetUnreadRegistrationApplicationCount(
         GetUnreadRegistrationApplicationCountForm form,
         CancellationToken cancellationToken = default
     ) =>
         SendAsync<GetUnreadRegistrationApplicationCountResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Leaves admin role.
-    /// </summary>
-    /// <param name="form">The form to send for leaving the admin role.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after leaving the admin role.
-    /// </returns>
     public Task<GetSiteResponse> LeaveAdmin(LeaveAdminForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetSiteResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Likes a comment.
-    /// </summary>
-    /// <param name="form">The form to send for liking a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after liking the comment.
-    /// </returns>
     public Task<CommentResponse> LikeComment(LikeCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Likes a post.
-    /// </summary>
-    /// <param name="form">The form to send for liking a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after liking the post.
-    /// </returns>
     public Task<PostResponse> LikePost(LikePostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Lists comment reports.
-    /// </summary>
-    /// <param name="form">The form to send for listing comment reports.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the listed comment reports.
-    /// </returns>
     public Task<ListCommentReportsResponse> ListCommentReports(ListCommentReportsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ListCommentReportsResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Lists communities.
-    /// </summary>
-    /// <param name="form">The form to send for listing communities.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the listed communities.
-    /// </returns>
+    
     public Task<ListCommunitiesResponse> ListCommunities(ListCommunitiesForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ListCommunitiesResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Lists post reports.
-    /// </summary>
-    /// <param name="form">The form to send for listing post reports.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the listed post reports.
-    /// </returns>
     public Task<ListPostReportsResponse> ListPostReports(ListPostReportsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ListPostReportsResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Lists private message reports.
-    /// </summary>
-    /// <param name="form">The form to send for listing private message reports.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the listed private message reports.
-    /// </returns>
     public Task<ListPrivateMessageReportsResponse> ListPrivateMessageReports(ListPrivateMessageReportsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ListPrivateMessageReportsResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Lists registration applications.
-    /// </summary>
-    /// <param name="form">The form to send for listing registration applications.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response with the listed registration applications.
-    /// </returns>
+    
     public Task<ListRegistrationApplicationsResponse> ListRegistrationApplications(ListRegistrationApplicationsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ListRegistrationApplicationsResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Locks a post.
-    /// </summary>
-    /// <param name="form">The form to send for locking a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after locking the post.
-    /// </returns>
+    
     public Task<PostResponse> LockPost(LockPostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Performs login.
-    /// </summary>
-    /// <param name="form">The form to send for performing login.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after performing login.
-    /// </returns>
+    
     public Task<LoginResponse> Login(LoginForm form, CancellationToken cancellationToken = default) =>
         SendAsync<LoginResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Marks everything as read.
-    /// </summary>
-    /// <param name="form">The form to send for marking all replies as read.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after marking all replies as read.
-    /// </returns>
+    
     public Task<GetRepliesResponse> MarkAllAsRead(MarkAllAsReadForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetRepliesResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Marks a comment reply as read.
-    /// </summary>
-    /// <param name="form">The form to send for marking a comment reply as read.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after marking the comment reply as read.
-    /// </returns>
+    
     public Task<CommentResponse> MarkCommentReplyAsRead(MarkCommentReplyAsReadForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Marks a person mention as read.
-    /// </summary>
-    /// <param name="form">The form to send for marking a person mention as read.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after marking the person mention as read.
-    /// </returns>
+    
     public Task<PersonMentionResponse> MarkPersonMentionAsRead(MarkPersonMentionAsReadForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PersonMentionResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Marks a post as read.
-    /// </summary>
-    /// <param name="form">The form to send for marking a post as read.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after marking the post as read.
-    /// </returns>
+    
     public Task<PostResponse> MarkPostAsRead(MarkPostAsReadForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Marks a private message as read.
-    /// </summary>
-    /// <param name="form">The form to send for marking a private message as read.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after marking the private message as read.
-    /// </returns>
+    
     public Task<PrivateMessageResponse> MarkPrivateMessageAsRead(MarkPrivateMessageAsReadForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessageResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Performs a password change.
-    /// </summary>
-    /// <param name="form">The form to send for performing a password change.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after performing the password change.
-    /// </returns>
+    
     public Task<LoginResponse> PasswordChange(PasswordChangeForm form, CancellationToken cancellationToken = default) =>
         SendAsync<LoginResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Performs a password reset.
-    /// </summary>
-    /// <param name="form">The form to send for performing a password reset.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after performing the password reset.
-    /// </returns>
+    
     public Task<PasswordResetResponse> PasswordReset(PasswordResetForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PasswordResetResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Purges a comment.
-    /// </summary>
-    /// <param name="form">The form to send for purging a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after purging the comment.
-    /// </returns>
     public Task<PurgeItemResponse> PurgeComment(PurgeCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PurgeItemResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Purges a community.
-    /// </summary>
-    /// <param name="form">The form to send for purging a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after purging the community.
-    /// </returns>
+    
     public Task<PurgeItemResponse> PurgeCommunity(PurgeCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PurgeItemResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Purges a person.
-    /// </summary>
-    /// <param name="form">The form to send for purging a person.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after purging the person.
-    /// </returns>
+    
     public Task<PurgeItemResponse> PurgePerson(PurgePersonForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PurgeItemResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Purges a post.
-    /// </summary>
-    /// <param name="form">The form to send for purging a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after purging the post.
-    /// </returns>
     public Task<PurgeItemResponse> PurgePost(PurgePostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PurgeItemResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Registers a new account.
-    /// </summary>
-    /// <param name="form">The form to send for registering a new account.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after registering the account.
-    /// </returns>
     public Task<LoginResponse> Register(RegisterForm form, CancellationToken cancellationToken = default) =>
         SendAsync<LoginResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Removes a comment.
-    /// </summary>
-    /// <param name="form">The form to send for removing a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after removing the comment.
-    /// </returns>
+    
     public Task<CommentResponse> RemoveComment(RemoveCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Removes a community.
-    /// </summary>
-    /// <param name="form">The form to send for removing a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after removing the community.
-    /// </returns>
+    
     public Task<CommunityResponse> RemoveCommunity(RemoveCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommunityResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Resolves a comment report.
-    /// </summary>
-    /// <param name="form">The form to send for resolving a comment report.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after resolving the comment report.
-    /// </returns>
     public Task<CommentReportResponse> ResolveCommentReport(ResolveCommentReportForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentReportResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Resolves an object.
-    /// </summary>
-    /// <param name="form">The form to send for resolving an object.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after resolving the object.
-    /// </returns>
+    
     public Task<ResolveObjectResponse> ResolveObject(ResolveObjectForm form, CancellationToken cancellationToken = default) =>
         SendAsync<ResolveObjectResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Resolves a post report.
-    /// </summary>
-    /// <param name="form">The form to send for resolving a post report.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after resolving the post report.
-    /// </returns>
+    
     public Task<PostReportResponse> ResolvePostReport(ResolvePostReportForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostReportResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Resolves a private message report.
-    /// </summary>
-    /// <param name="form">The form to send for resolving a private message report.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after resolving the private message report.
-    /// </returns>
+    
     public Task<PrivateMessageReportResponse> ResolvePrivateMessageReport(ResolvePrivateMessageReportForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PrivateMessageReportResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Saves a comment.
-    /// </summary>
-    /// <param name="form">The form to send for saving a comment.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after saving the comment.
-    /// </returns>
+    
     public Task<CommentResponse> SaveComment(SaveCommentForm form, CancellationToken cancellationToken = default) =>
         SendAsync<CommentResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Saves a post.
-    /// </summary>
-    /// <param name="form">The form to send for saving a post.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after saving the post.
-    /// </returns>
+    
     public Task<PostResponse> SavePost(SavePostForm form, CancellationToken cancellationToken = default) =>
         SendAsync<PostResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Saves user settings.
-    /// </summary>
-    /// <param name="form">The form to send for saving user settings.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after saving the user settings.
-    /// </returns>
+    
     public Task<LoginResponse> SaveUserSettings(SaveUserSettingsForm form, CancellationToken cancellationToken = default) =>
         SendAsync<LoginResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Performs a search.
-    /// </summary>
-    /// <param name="form">The form to send for performing a search.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after performing the search.
-    /// </returns>
+    
     public Task<SearchResponse> Search(SearchForm form, CancellationToken cancellationToken = default) =>
         SendAsync<SearchResponse>(form, cancellationToken);
-
-    /// <summary>
-    /// Transfers a community to another moderator.
-    /// </summary>
-    /// <param name="form">The form to send for transferring a community.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after transferring the community.
-    /// </returns>
+    
     public Task<GetCommunityResponse> TransferCommunity(TransferCommunityForm form, CancellationToken cancellationToken = default) =>
         SendAsync<GetCommunityResponse>(form, cancellationToken);
 
-    /// <summary>
-    /// Verifies an email for log in.
-    /// </summary>
-    /// <param name="form">The form to send for verifying an email.</param>
-    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
-    /// <returns>
-    /// The task object representing the asynchronous operation. The task result contains the response after verifying the email.
-    /// </returns>
     public Task<VerifyEmailResponse> VerifyEmail(VerifyEmailForm form, CancellationToken cancellationToken = default) =>
         SendAsync<VerifyEmailResponse>(form, cancellationToken);
 }

--- a/dotNETLemmy.API/Types/Forms/AddAdminForm.cs
+++ b/dotNETLemmy.API/Types/Forms/AddAdminForm.cs
@@ -6,6 +6,6 @@ public class AddAdminForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int PersonId { get; set; }
 
-    public string EndPoint => "/admin/add";
+    public string EndPoint => "/api/v3/admin/add";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/AddModToCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/AddModToCommunityForm.cs
@@ -6,6 +6,6 @@ public class AddModToCommunityForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int CommunityId { get; set; }
     public int PersonId { get; set; }
-    public string EndPoint => "/community/mod";
+    public string EndPoint => "/api/v3/community/mod";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/ApproveRegistrationApplicationForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ApproveRegistrationApplicationForm.cs
@@ -6,6 +6,6 @@ public class ApproveRegistrationApplicationForm : IForm
     public string Auth { get; set; } = string.Empty;
     public string? DenyReason { get; set; }
     public int Id { get; set; }
-    public string EndPoint => "/admin/registration_application/approve";
+    public string EndPoint => "/api/v3/admin/registration_application/approve";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/BanFromCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/BanFromCommunityForm.cs
@@ -9,6 +9,6 @@ public class BanFromCommunityForm : IForm
     public int PersonId { get; set; }
     public string? Reason { get; set; }
     public bool? RemoveData { get; set; }
-    public string EndPoint => "/community/ban_user";
+    public string EndPoint => "/api/v3/community/ban_user";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/BanPersonForm.cs
+++ b/dotNETLemmy.API/Types/Forms/BanPersonForm.cs
@@ -8,6 +8,6 @@ public class BanPersonForm : IForm
     public int PersonId { get; set; }
     public string? Reason { get; set; }
     public bool? RemoveData { get; set; }
-    public string EndPoint => "/user/ban";
+    public string EndPoint => "/api/v3/user/ban";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/BlockCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/BlockCommunityForm.cs
@@ -5,6 +5,6 @@ public class BlockCommunityForm : IForm
     public string Auth { get; set; } = string.Empty;
     public bool Block { get; set; }
     public int CommunityId { get; set; }
-    public string EndPoint => "/community/block";
+    public string EndPoint => "/api/v3/community/block";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/BlockPersonForm.cs
+++ b/dotNETLemmy.API/Types/Forms/BlockPersonForm.cs
@@ -5,6 +5,6 @@ public class BlockPersonForm : IForm
     public string Auth { get; set; } = string.Empty;
     public bool Block { get; set; }
     public int PersonId { get; set; }
-    public string EndPoint => "/user/block";
+    public string EndPoint => "/api/v3/user/block";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/ChangePasswordForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ChangePasswordForm.cs
@@ -6,6 +6,6 @@ public class ChangePasswordForm : IForm
     public string NewPassword { get; set; } = string.Empty;
     public string NewPasswordVerify { get; set; } = string.Empty;
     public string OldPassword { get; set; } = string.Empty;
-    public string EndPoint => "/user/change_password";
+    public string EndPoint => "/api/v3/user/change_password";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/CreateCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreateCommentForm.cs
@@ -8,6 +8,6 @@ public class CreateCommentForm : IForm
     public int? LanguageId { get; set; }
     public int? ParentId { get; set; }
     public int PostId { get; set; }
-    public string EndPoint => "/comment";
+    public string EndPoint => "/api/v3/comment";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreateCommentReportForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreateCommentReportForm.cs
@@ -5,6 +5,6 @@ public class CreateCommentReportForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int CommentId { get; set; }
     public string Reason { get; set; } = string.Empty;
-    public string EndPoint => "/comment/report";
+    public string EndPoint => "/api/v3/comment/report";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreateCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreateCommunityForm.cs
@@ -11,6 +11,6 @@ public class CreateCommunityForm : IForm
     public bool? Nsfw { get; set; }
     public bool? PostingRestrictedToMods { get; set; }
     public string Title { get; set; } = string.Empty;
-    public string EndPoint => "/community";
+    public string EndPoint => "/api/v3/community";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreatePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreatePostForm.cs
@@ -10,6 +10,6 @@ public class CreatePostForm : IForm
     public string Name { get; set; } = string.Empty;
     public bool? Nsfw { get; set; }
     public string? Url { get; set; }
-    public string EndPoint => "/post";
+    public string EndPoint => "/api/v3/post";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreatePostReportForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreatePostReportForm.cs
@@ -5,6 +5,6 @@ public class CreatePostReportForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int PostId { get; set; }
     public string Reason { get; set; } = string.Empty;
-    public string EndPoint => "/post/report";
+    public string EndPoint => "/api/v3/post/report";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreatePrivateMessageForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreatePrivateMessageForm.cs
@@ -5,6 +5,6 @@ public class CreatePrivateMessageForm : IForm
     public string Auth { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public int Recipient { get; set; }
-    public string EndPoint => "/private_message";
+    public string EndPoint => "/api/v3/private_message";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreatePrivateMessageReportForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreatePrivateMessageReportForm.cs
@@ -5,6 +5,6 @@ public class CreatePrivateMessageReportForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int PrivateMessageId { get; set; }
     public string Reason { get; set; } = string.Empty;
-    public string EndPoint => "/private_message/report";
+    public string EndPoint => "/api/v3/private_message/report";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/CreateSiteForm.cs
+++ b/dotNETLemmy.API/Types/Forms/CreateSiteForm.cs
@@ -50,6 +50,6 @@ public class CreateSiteForm : IForm
     public string? Sidebar { get; set; }
     public string? SlurFilterRegex { get; set; }
     public string[]? Taglines { get; set; }
-    public string EndPoint => "/site";
+    public string EndPoint => "/api/v3/site";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/DeleteAccountForm.cs
+++ b/dotNETLemmy.API/Types/Forms/DeleteAccountForm.cs
@@ -4,6 +4,6 @@ public class DeleteAccountForm : IForm
 {
     public string Auth { get; set; } = string.Empty;
     public string Password { get; set; } = string.Empty;
-    public string EndPoint => "/user/delete_account";
+    public string EndPoint => "/api/v3/user/delete_account";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/DeleteCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/DeleteCommentForm.cs
@@ -5,6 +5,6 @@ public class DeleteCommentForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int CommentId { get; set; }
     public bool Deleted { get; set; }
-    public string EndPoint => "/comment/delete";
+    public string EndPoint => "/api/v3/comment/delete";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/DeleteCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/DeleteCommunityForm.cs
@@ -5,6 +5,6 @@ public class DeleteCommunityForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int CommunityId { get; set; }
     public bool Deleted { get; set; }
-    public string EndPoint => "/community/delete";
+    public string EndPoint => "/api/v3/community/delete";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/DeletePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/DeletePostForm.cs
@@ -5,6 +5,6 @@ public class DeletePostForm : IForm
     public string Auth { get; set; } = string.Empty;
     public bool Deleted { get; set; }
     public int PostId { get; set; }
-    public string EndPoint => "/post/delete";
+    public string EndPoint => "/api/v3/post/delete";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/DeletePrivateMessageForm.cs
+++ b/dotNETLemmy.API/Types/Forms/DeletePrivateMessageForm.cs
@@ -5,6 +5,6 @@ public class DeletePrivateMessageForm : IForm
     public string Auth { get; set; } = string.Empty;
     public bool Deleted { get; set; }
     public int PrivateMessageId { get; set; }
-    public string EndPoint => "/private_message/delete";
+    public string EndPoint => "/api/v3/private_message/delete";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/EditCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/EditCommentForm.cs
@@ -8,6 +8,6 @@ public class EditCommentForm : IForm
     public bool? Distinguished { get; set; }
     public string? FormId { get; set; }
     public int? LanguageId { get; set; }
-    public string EndPoint => "/comment";
+    public string EndPoint => "/api/v3/comment";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/EditCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/EditCommunityForm.cs
@@ -11,6 +11,6 @@ public class EditCommunityForm : IForm
     public bool? Nsfw { get; set; }
     public bool? PostingRestrictedToMods { get; set; }
     public string? Title { get; set; }
-    public string EndPoint => "/community";
+    public string EndPoint => "/api/v3/community";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/EditPostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/EditPostForm.cs
@@ -9,6 +9,6 @@ public class EditPostForm : IForm
     public bool? Nsfw { get; set; }
     public int PostId { get; set; }
     public string? Url { get; set; }
-    public string EndPoint => "/post";
+    public string EndPoint => "/api/v3/post";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/EditPrivateMessageForm.cs
+++ b/dotNETLemmy.API/Types/Forms/EditPrivateMessageForm.cs
@@ -5,6 +5,6 @@ public class EditPrivateMessageForm : IForm
     public string Auth { get; set; } = string.Empty;
     public string Content { get; set; } = string.Empty;
     public int PrivateMessageId { get; set; }
-    public string EndPoint => "/private_message";
+    public string EndPoint => "/api/v3/private_message";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/EditSiteForm.cs
+++ b/dotNETLemmy.API/Types/Forms/EditSiteForm.cs
@@ -50,6 +50,6 @@ public class EditSiteForm : IForm
     public string? Sidebar { get; set; }
     public string? SlurFilterRegex { get; set; }
     public string[]? Taglines { get; set; }
-    public string EndPoint => "/site";
+    public string EndPoint => "/api/v3/site";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/FeaturePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/FeaturePostForm.cs
@@ -8,6 +8,6 @@ public class FeaturePostForm : IForm
     public PostFeatureType FeatureType { get; set; }
     public bool Featured { get; set; }
     public int PostId { get; set; }
-    public string EndPoint => "/post/feature";
+    public string EndPoint => "/api/v3/post/feature";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/FollowCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/FollowCommunityForm.cs
@@ -5,6 +5,6 @@ public class FollowCommunityForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int CommunityId { get; set; }
     public bool Follow { get; set; }
-    public string EndPoint => "/community/follow";
+    public string EndPoint => "/api/v3/community/follow";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/GetBannedPersonsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetBannedPersonsForm.cs
@@ -3,6 +3,6 @@ namespace dotNETLemmy.API.Types.Forms;
 public class GetBannedPersonsForm : IForm
 {
     public string Auth { get; set; } = string.Empty;
-    public string EndPoint => "/user/banned";
+    public string EndPoint => "/api/v3/user/banned";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetCaptchaForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetCaptchaForm.cs
@@ -2,6 +2,6 @@ namespace dotNETLemmy.API.Types.Forms;
 
 public class GetCaptchaForm : IForm
 {
-    public string EndPoint => "/user/get_captcha";
+    public string EndPoint => "/api/v3/user/get_captcha";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetCommentsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetCommentsForm.cs
@@ -23,6 +23,6 @@ public class GetCommentsForm : IForm
     [JsonProperty(PropertyName = "type_")]
     public ListingType Type { get; set; }
 
-    public string EndPoint => "/comment/list";
+    public string EndPoint => "/api/v3/comment/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetCommunityForm.cs
@@ -5,6 +5,6 @@ public class GetCommunityForm : IForm
     public string? Auth { get; set; }
     public int? Id { get; set; }
     public string? Name { get; set; }
-    public string EndPoint => "/community";
+    public string EndPoint => "/api/v3/community";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetModlogForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetModlogForm.cs
@@ -17,6 +17,6 @@ public class GetModlogForm : IForm
     [JsonProperty(PropertyName = "type_")]
     public ModlogActionType Type { get; set; }
 
-    public string EndPoint => "/modlog";
+    public string EndPoint => "/api/v3/modlog";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetPersonDetailsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetPersonDetailsForm.cs
@@ -17,6 +17,6 @@ public class GetPersonDetailsForm : IForm
 
     public string? Username { get; set; }
 
-    public string EndPoint => "/user";
+    public string EndPoint => "/api/v3/user";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetPersonMentionsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetPersonMentionsForm.cs
@@ -15,6 +15,6 @@ public class GetPersonMentionsForm : IForm
     public int? Page { get; set; }
     public bool? UnreadOnly { get; set; }
 
-    public string EndPoint => "/user/mention";
+    public string EndPoint => "/api/v3/user/mention";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetPostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetPostForm.cs
@@ -6,6 +6,6 @@ public class GetPostForm : IForm
     public int? CommentId { get; set; }
     public int? Id { get; set; }
 
-    public string EndPoint => "/post";
+    public string EndPoint => "/api/v3/post";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetPostsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetPostsForm.cs
@@ -20,6 +20,6 @@ public class GetPostsForm : IForm
     [JsonProperty(PropertyName = "type_")]
     public ListingType? Type { get; set; }
 
-    public string EndPoint => "/post/list";
+    public string EndPoint => "/api/v3/post/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetPrivateMessagesForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetPrivateMessagesForm.cs
@@ -7,6 +7,6 @@ public class GetPrivateMessagesForm : IForm
     public int? Page { get; set; }
     public bool? UnreadOnly { get; set; }
 
-    public string EndPoint => "/private_message/list";
+    public string EndPoint => "/api/v3/private_message/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetRepliesForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetRepliesForm.cs
@@ -15,6 +15,6 @@ public class GetRepliesForm : IForm
 
     public bool? UnreadOnly { get; set; }
 
-    public string EndPoint => "/user/replies";
+    public string EndPoint => "/api/v3/user/replies";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetReportCountForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetReportCountForm.cs
@@ -5,6 +5,6 @@ public class GetReportCountForm : IForm
     public string Auth { get; set; } = string.Empty;
     public int? CommunityId { get; set; }
 
-    public string EndPoint => "/user/report_count";
+    public string EndPoint => "/api/v3/user/report_count";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetSiteForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetSiteForm.cs
@@ -4,6 +4,6 @@ public class GetSiteForm : IForm
 {
     public string? Auth { get; set; }
 
-    public string EndPoint => "/site";
+    public string EndPoint => "/api/v3/site";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetSiteMetadataForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetSiteMetadataForm.cs
@@ -4,6 +4,6 @@ public class GetSiteMetadataForm : IForm
 {
     public string Url { get; set; } = string.Empty;
 
-    public string EndPoint => "/post/site_metadata";
+    public string EndPoint => "/api/v3/post/site_metadata";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetUnreadCountForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetUnreadCountForm.cs
@@ -4,6 +4,6 @@ public class GetUnreadCountForm : IForm
 {
     public string Auth { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/unread_count";
+    public string EndPoint => "/api/v3/user/unread_count";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/GetUnreadRegistrationApplicationCountForm.cs
+++ b/dotNETLemmy.API/Types/Forms/GetUnreadRegistrationApplicationCountForm.cs
@@ -4,6 +4,6 @@ public class GetUnreadRegistrationApplicationCountForm : IForm
 {
     public string Auth { get; set; } = string.Empty;
 
-    public string EndPoint => "/admin/registration_application/count";
+    public string EndPoint => "/api/v3/admin/registration_application/count";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/LeaveAdminForm.cs
+++ b/dotNETLemmy.API/Types/Forms/LeaveAdminForm.cs
@@ -4,6 +4,6 @@ public class LeaveAdminForm : IForm
 {
     public string Auth { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/leave_admin";
+    public string EndPoint => "/api/v3/user/leave_admin";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/LikeCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/LikeCommentForm.cs
@@ -6,6 +6,6 @@ public class LikeCommentForm : IForm
     public int CommentId { get; set; }
     public int Score { get; set; }
 
-    public string EndPoint => "/post/like";
+    public string EndPoint => "/api/v3/post/like";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/LikePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/LikePostForm.cs
@@ -6,6 +6,6 @@ public class LikePostForm : IForm
     public int PostId { get; set; }
     public int Score { get; set; }
 
-    public string EndPoint => "/post/like";
+    public string EndPoint => "/api/v3/post/like";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/ListCommentReportsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ListCommentReportsForm.cs
@@ -8,6 +8,6 @@ public class ListCommentReportsForm : IForm
     public int? Page { get; set; }
     public bool? UnresolvedOnly { get; set; }
 
-    public string EndPoint => "/comment/report/list";
+    public string EndPoint => "/api/v3/comment/report/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/ListCommunitiesForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ListCommunitiesForm.cs
@@ -17,6 +17,6 @@ public class ListCommunitiesForm : IForm
     [JsonProperty(PropertyName = "type_")]
     public ListingType? Type { get; set; }
 
-    public string EndPoint => "/community/list";
+    public string EndPoint => "/api/v3/community/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/ListPostReportsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ListPostReportsForm.cs
@@ -8,6 +8,6 @@ public class ListPostReportsForm : IForm
     public int? Page { get; set; }
     public bool? UnresolvedOnly { get; set; }
 
-    public string EndPoint => "/post/report/list";
+    public string EndPoint => "/api/v3/post/report/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/ListPrivateMessageReportsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ListPrivateMessageReportsForm.cs
@@ -7,6 +7,6 @@ public class ListPrivateMessageReportsForm : IForm
     public int? Page { get; set; }
     public bool? UnresolvedOnly { get; set; }
 
-    public string EndPoint => "/private_message/report/list";
+    public string EndPoint => "/api/v3/private_message/report/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/ListRegistrationApplicationsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ListRegistrationApplicationsForm.cs
@@ -7,6 +7,6 @@ public class ListRegistrationApplicationsForm : IForm
     public int? Page { get; set; }
     public bool? UnreadOnly { get; set; }
 
-    public string EndPoint => "/admin/registration_application/list";
+    public string EndPoint => "/api/v3/admin/registration_application/list";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/LockPostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/LockPostForm.cs
@@ -6,6 +6,6 @@ public class LockPostForm : IForm
     public bool Locked { get; set; }
     public int PostId { get; set; }
 
-    public string EndPoint => "/post/lock";
+    public string EndPoint => "/api/v3/post/lock";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/LoginForm.cs
+++ b/dotNETLemmy.API/Types/Forms/LoginForm.cs
@@ -4,6 +4,6 @@ public class LoginForm : IForm
 {
     public string UsernameOrEmail { get; init; } = null!;
     public string Password { get; init; } = null!;
-    public string EndPoint => "/user/login";
+    public string EndPoint => "/api/v3/user/login";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/MarkAllAsReadForm.cs
+++ b/dotNETLemmy.API/Types/Forms/MarkAllAsReadForm.cs
@@ -4,6 +4,6 @@ public class MarkAllAsReadForm : IForm
 {
     public string Auth { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/mark_all_as_read";
+    public string EndPoint => "/api/v3/user/mark_all_as_read";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/MarkCommentReplyAsReadForm.cs
+++ b/dotNETLemmy.API/Types/Forms/MarkCommentReplyAsReadForm.cs
@@ -6,6 +6,6 @@ public class MarkCommentReplyAsReadForm : IForm
     public int CommentReplyId { get; set; }
     public bool Read { get; set; }
 
-    public string EndPoint => "/comment/mark_as_read";
+    public string EndPoint => "/api/v3/comment/mark_as_read";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/MarkPersonMentionAsReadForm.cs
+++ b/dotNETLemmy.API/Types/Forms/MarkPersonMentionAsReadForm.cs
@@ -6,6 +6,6 @@ public class MarkPersonMentionAsReadForm : IForm
     public int PersonMentionId { get; set; }
     public bool Read { get; set; }
 
-    public string EndPoint => "/user/mention/mark_as_read";
+    public string EndPoint => "/api/v3/user/mention/mark_as_read";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/MarkPostAsReadForm.cs
+++ b/dotNETLemmy.API/Types/Forms/MarkPostAsReadForm.cs
@@ -6,6 +6,6 @@ public class MarkPostAsReadForm : IForm
     public int PostId { get; set; }
     public bool Read { get; set; }
 
-    public string EndPoint => "/post/mark_as_read";
+    public string EndPoint => "/api/v3/post/mark_as_read";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/MarkPrivateMessageAsReadForm.cs
+++ b/dotNETLemmy.API/Types/Forms/MarkPrivateMessageAsReadForm.cs
@@ -6,6 +6,6 @@ public class MarkPrivateMessageAsReadForm : IForm
     public int PrivateMessageId { get; set; }
     public bool Read { get; set; }
 
-    public string EndPoint => "/private_message/mark_as_read";
+    public string EndPoint => "/api/v3/private_message/mark_as_read";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/PasswordChangeForm.cs
+++ b/dotNETLemmy.API/Types/Forms/PasswordChangeForm.cs
@@ -6,6 +6,6 @@ public class PasswordChangeForm : IForm
     public string PasswordVerify { get; set; } = string.Empty;
     public string Token { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/password_change";
+    public string EndPoint => "/api/v3/user/password_change";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/PasswordResetForm.cs
+++ b/dotNETLemmy.API/Types/Forms/PasswordResetForm.cs
@@ -4,6 +4,6 @@ public class PasswordResetForm : IForm
 {
     public string Email { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/password_reset";
+    public string EndPoint => "/api/v3/user/password_reset";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/PurgeCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/PurgeCommentForm.cs
@@ -6,6 +6,6 @@ public class PurgeCommentForm : IForm
     public int CommentId { get; set; }
     public string? Reason { get; set; }
 
-    public string EndPoint => "/admin/purge/comment";
+    public string EndPoint => "/api/v3/admin/purge/comment";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/PurgeCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/PurgeCommunityForm.cs
@@ -6,6 +6,6 @@ public class PurgeCommunityForm : IForm
     public int CommunityId { get; set; }
     public string? Reason { get; set; }
 
-    public string EndPoint => "/admin/purge/community";
+    public string EndPoint => "/api/v3/admin/purge/community";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/PurgePersonForm.cs
+++ b/dotNETLemmy.API/Types/Forms/PurgePersonForm.cs
@@ -6,6 +6,6 @@ public class PurgePersonForm : IForm
     public int PersonId { get; set; }
     public string? Reason { get; set; }
 
-    public string EndPoint => "/admin/purge/person";
+    public string EndPoint => "/api/v3/admin/purge/person";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/PurgePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/PurgePostForm.cs
@@ -6,6 +6,6 @@ public class PurgePostForm : IForm
     public int PostId { get; set; }
     public string? Reason { get; set; }
 
-    public string EndPoint => "/admin/purge/post";
+    public string EndPoint => "/api/v3/admin/purge/post";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/RegisterForm.cs
+++ b/dotNETLemmy.API/Types/Forms/RegisterForm.cs
@@ -12,6 +12,6 @@ public class RegisterForm : IForm
     public bool ShowNsfw { get; set; }
     public string Username { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/register";
+    public string EndPoint => "/api/v3/user/register";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/RemoveCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/RemoveCommentForm.cs
@@ -7,6 +7,6 @@ public class RemoveCommentForm : IForm
     public string? Reason { get; set; }
     public bool Removed { get; set; }
 
-    public string EndPoint => "/comment/remove";
+    public string EndPoint => "/api/v3/comment/remove";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/RemoveCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/RemoveCommunityForm.cs
@@ -8,6 +8,6 @@ public class RemoveCommunityForm : IForm
     public string? Reason { get; set; }
     public bool Removed { get; set; }
 
-    public string EndPoint => "/community/remove";
+    public string EndPoint => "/api/v3/community/remove";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/RemovePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/RemovePostForm.cs
@@ -7,6 +7,6 @@ public class RemovePostForm : IForm
     public string? Reason { get; set; }
     public bool Removed { get; set; }
 
-    public string EndPoint => "/post/remove";
+    public string EndPoint => "/api/v3/post/remove";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/ResolveCommentReportForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ResolveCommentReportForm.cs
@@ -6,6 +6,6 @@ public class ResolveCommentReportForm : IForm
     public int ReportId { get; set; }
     public bool Resolved { get; set; }
 
-    public string EndPoint => "/comment/report/resolve";
+    public string EndPoint => "/api/v3/comment/report/resolve";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/ResolveObjectForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ResolveObjectForm.cs
@@ -5,6 +5,6 @@ public class ResolveObjectForm : IForm
     public string? Auth { get; set; }
     public string Q { get; set; } = string.Empty;
 
-    public string EndPoint => "/resolve_object";
+    public string EndPoint => "/api/v3/resolve_object";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/ResolvePostReportForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ResolvePostReportForm.cs
@@ -6,6 +6,6 @@ public class ResolvePostReportForm : IForm
     public int ReportId { get; set; }
     public bool Resolved { get; set; }
 
-    public string EndPoint => "/post/report/resolve";
+    public string EndPoint => "/api/v3/post/report/resolve";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/ResolvePrivateMessageReportForm.cs
+++ b/dotNETLemmy.API/Types/Forms/ResolvePrivateMessageReportForm.cs
@@ -6,6 +6,6 @@ public class ResolvePrivateMessageReportForm : IForm
     public int ReportId { get; set; }
     public bool Resolved { get; set; }
 
-    public string EndPoint => "/private_message/report/resolve";
+    public string EndPoint => "/api/v3/private_message/report/resolve";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/SaveCommentForm.cs
+++ b/dotNETLemmy.API/Types/Forms/SaveCommentForm.cs
@@ -6,6 +6,6 @@ public class SaveCommentForm : IForm
     public int CommentId { get; set; }
     public bool Save { get; set; }
 
-    public string EndPoint => "/comment/save";
+    public string EndPoint => "/api/v3/comment/save";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/SavePostForm.cs
+++ b/dotNETLemmy.API/Types/Forms/SavePostForm.cs
@@ -6,6 +6,6 @@ public class SavePostForm : IForm
     public int PostId { get; set; }
     public bool Save { get; set; }
 
-    public string EndPoint => "/post/save";
+    public string EndPoint => "/api/v3/post/save";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/SaveUserSettingsForm.cs
+++ b/dotNETLemmy.API/Types/Forms/SaveUserSettingsForm.cs
@@ -23,6 +23,6 @@ public class SaveUserSettingsForm : IForm
     public bool? ShowScores { get; set; }
     public string? Theme { get; set; }
 
-    public string EndPoint => "/user/save_user_settings";
+    public string EndPoint => "/api/v3/user/save_user_settings";
     public HttpMethod Method => HttpMethod.Put;
 }

--- a/dotNETLemmy.API/Types/Forms/SearchForm.cs
+++ b/dotNETLemmy.API/Types/Forms/SearchForm.cs
@@ -24,6 +24,6 @@ public class SearchForm : IForm
     [JsonProperty(PropertyName = "type_")]
     public SearchType? Type { get; set; }
 
-    public string EndPoint => "/search";
+    public string EndPoint => "/api/v3/search";
     public HttpMethod Method => HttpMethod.Get;
 }

--- a/dotNETLemmy.API/Types/Forms/TransferCommunityForm.cs
+++ b/dotNETLemmy.API/Types/Forms/TransferCommunityForm.cs
@@ -6,6 +6,6 @@ public class TransferCommunityForm : IForm
     public int CommunityId { get; set; }
     public int PersonId { get; set; }
 
-    public string EndPoint => "/community/transfer";
+    public string EndPoint => "/api/v3/community/transfer";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Forms/VerifyEmailForm.cs
+++ b/dotNETLemmy.API/Types/Forms/VerifyEmailForm.cs
@@ -4,6 +4,6 @@ public class VerifyEmailForm : IForm
 {
     public string Token { get; set; } = string.Empty;
 
-    public string EndPoint => "/user/verify_email";
+    public string EndPoint => "/api/v3/user/verify_email";
     public HttpMethod Method => HttpMethod.Post;
 }

--- a/dotNETLemmy.API/Types/Interfaces/IForm.cs
+++ b/dotNETLemmy.API/Types/Interfaces/IForm.cs
@@ -11,19 +11,18 @@ public interface IForm : IJsonObject
 {
     [JsonIgnore] public string EndPoint { get; }
     [JsonIgnore] public HttpMethod Method { get; }
-    [JsonIgnore] private string RequestUri => $"/api/v3/{EndPoint.TrimStart('/').TrimEnd('/')}";
     
-
-    public HttpRequestMessage ToRequest(Uri baseUri)
+    public HttpRequestMessage ToRequest(string baseUri)
     {
-        var requestUri = RequestUri;
-        if (Method == HttpMethod.Get ||
-            Method == HttpMethod.Head)
-            requestUri += Json.JsonToQuery();
+        var endPoint = EndPoint;
+        if ((Method == HttpMethod.Get ||
+            Method == HttpMethod.Head) &&
+            Json.Length > 0) 
+            endPoint += Json.JsonToQuery();
 
         var req = new HttpRequestMessage
         {
-            RequestUri = new Uri(baseUri, requestUri), Method = Method
+            RequestUri = new Uri(new Uri(baseUri), endPoint), Method = Method
         };
 
         if (Method != HttpMethod.Get &&

--- a/dotNETLemmy.API/Types/Interfaces/ILemmyHttpClient.cs
+++ b/dotNETLemmy.API/Types/Interfaces/ILemmyHttpClient.cs
@@ -1,0 +1,808 @@
+using dotNETLemmy.API.Types.Forms;
+using dotNETLemmy.API.Types.Responses;
+
+namespace dotNETLemmy.API.Types;
+
+public interface ILemmyHttpClient
+{
+    /// <summary>
+    ///     Sends an asynchronous HTTP request and returns the deserialized response.
+    ///     <para>
+    ///         Avoid calling directly unless the Lemmy instance requires non-standard API calls.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="TResponse">Deserialized response format, inherits <see cref="Response" /></typeparam>
+    /// <param name="form">The form data to be sent, inherits <see cref="IForm" /></param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>The deserialized response format</returns>
+    public Task<TResponse> SendAsync<TResponse>(IForm form, CancellationToken cancellationToken) where TResponse : Response, new();
+
+    /// <summary>
+    ///     Adds an administrator.
+    /// </summary>
+    /// <param name="form">The form to send for adding an administrator.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after adding an
+    ///     administrator.
+    /// </returns>
+    public Task<AddAdminResponse> AddAdmin(AddAdminForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Adds a moderator to a community.
+    /// </summary>
+    /// <param name="form">The form to send for adding a moderator to a community. </param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after adding a
+    ///     moderator to a community.
+    /// </returns>
+    public Task<AddModToCommunityResponse> AddModToCommunity(AddModToCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Approves a registration application.
+    /// </summary>
+    /// <param name="form">The form to send for approving a registration application.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after approving
+    ///     a registration application.
+    /// </returns>
+    public Task<ApproveRegistrationApplicationResponse> ApproveRegistrationApplication(ApproveRegistrationApplicationForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Bans a person from a community.
+    /// </summary>
+    /// <param name="form">The form to send for banning a person from a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after banning a
+    ///     person from a community.
+    /// </returns>
+    public Task<BanFromCommunityResponse> BanFromCommunity(BanFromCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Bans a person.
+    /// </summary>
+    /// <param name="form">The form to send for banning a person.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after banning a
+    ///     person.
+    /// </returns>
+    public Task<BanPersonResponse> BanPerson(BanPersonForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Blocks a community.
+    /// </summary>
+    /// <param name="form">The form to send for blocking a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after blocking
+    ///     a community.
+    /// </returns>
+    public Task<BlockCommunityResponse> BlockCommunity(BlockCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Blocks a person.
+    /// </summary>
+    /// <param name="form">The form to send for blocking a person.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after blocking
+    ///     a person.
+    /// </returns>
+    public Task<BlockPersonResponse> BlockPerson(BlockPersonForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Changes the password for the current user.
+    /// </summary>
+    /// <param name="form">The form to send for changing the password.></param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after changing
+    ///     the password. <see cref="LoginResponse" />
+    /// </returns>
+    public Task<LoginResponse> ChangePassword(ChangePasswordForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new comment.
+    /// </summary>
+    /// <param name="form">The form to send for creating a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a comment. <see cref="CommentResponse" />
+    /// </returns>
+    public Task<CommentResponse> CreateComment(CreateCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new community.
+    /// </summary>
+    /// <param name="form">The form to send for creating a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a community.
+    /// </returns>
+    public Task<CommunityResponse> CreateCommunity(CreateCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new post.
+    /// </summary>
+    /// <param name="form">The form to send for creating a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a post.
+    /// </returns>
+    public Task<PostResponse> CreatePost(CreatePostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new report for a post.
+    /// </summary>
+    /// <param name="form">The form to send for creating a post report.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a post report.
+    /// </returns>
+    public Task<PostReportResponse> CreatePostReport(CreatePostReportForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new private message.
+    /// </summary>
+    /// <param name="form">The form to send for creating a private message.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a private message.
+    /// </returns>
+    public Task<PrivateMessageResponse> CreatePrivateMessage(CreatePrivateMessageForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new report for a private message.
+    /// </summary>
+    /// <param name="form">The form to send for creating a private message report. </param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a private message report.
+    /// </returns>
+    public Task<PrivateMessageReportResponse> CreatePrivateMessageReport(CreatePrivateMessageReportForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Creates a new report for a private message.
+    /// </summary>
+    /// <param name="form">The form to send for creating a private message report. </param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after creating
+    ///     a private message report.
+    /// </returns>
+    public Task<SiteResponse> CreateSite(CreateSiteForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    ///     Deletes a user account.
+    /// </summary>
+    /// <param name="form">The form to send for deleting a user account.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    ///     The task object representing the asynchronous operation. The task result contains the response after deleting
+    ///     a user account.
+    /// </returns>
+    public Task<DeleteAccountResponse> DeleteAccount(DeleteAccountForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes a comment.
+    /// </summary>
+    /// <param name="form">The form to send for deleting a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after deleting the comment.
+    /// </returns>
+    public Task<CommentResponse> DeleteComment(DeleteCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes a community.
+    /// </summary>
+    /// <param name="form">The form to send for deleting a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after deleting the community.
+    /// </returns>
+    public Task<CommunityResponse> DeleteCommunity(DeleteCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes a post.
+    /// </summary>
+    /// <param name="form">The form to send for deleting a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after deleting the post.
+    /// </returns>
+    public Task<PostResponse> DeletePost(DeletePostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes a private message.
+    /// </summary>
+    /// <param name="form">The form to send for deleting a private message.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after deleting the private message.
+    /// </returns>
+    public Task<PrivateMessageResponse> DeletePrivateMessage(DeletePrivateMessageForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edits a comment.
+    /// </summary>
+    /// <param name="form">The form to send for editing a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after editing the comment.
+    /// </returns>
+    public Task<CommentResponse> EditComment(EditCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edits a community.
+    /// </summary>
+    /// <param name="form">The form to send for editing a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after editing the community.
+    /// </returns>
+    public Task<CommunityResponse> EditCommunity(EditCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edits a post.
+    /// </summary>
+    /// <param name="form">The form to send for editing a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after editing the post.
+    /// </returns>
+    public Task<PostResponse> EditPost(EditPostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edits a private message.
+    /// </summary>
+    /// <param name="form">The form to send for editing a private message.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after editing the private message.
+    /// </returns>
+    public Task<PrivateMessageResponse> EditPrivateMessage(EditPrivateMessageForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Edits a site.
+    /// </summary>
+    /// <param name="form">The form to send for editing a site.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after editing the site.
+    /// </returns>
+    public Task<SiteResponse> EditSite(EditSiteForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Features a post.
+    /// </summary>
+    /// <param name="form">The form to send for featuring a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after featuring the post.
+    /// </returns>
+    public Task<PostResponse> FeaturePost(FeaturePostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Follows a community.
+    /// </summary>
+    /// <param name="form">The form to send for following a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after following the community.
+    /// </returns>
+    public Task<CommunityResponse> FollowCommunity(FollowCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the list of banned persons.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the list of banned persons.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the list of banned persons.
+    /// </returns>
+    public Task<BannedPersonsResponse> GetBannedPersons(GetBannedPersonsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a captcha.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving a captcha.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved captcha.
+    /// </returns>
+    public Task<GetCaptchaResponse> GetCaptcha(GetCaptchaForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets comments.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving comments.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved comments.
+    /// </returns>
+    public Task<GetCommentsResponse> GetComments(GetCommentsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a community.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved community.
+    /// </returns>
+    public Task<GetCommunityResponse> GetCommunity(GetCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the modlog.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the modlog.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved modlog.
+    /// </returns>
+    public Task<GetModlogResponse> GetModlog(GetModlogForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the details of a person.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the person details.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved person details.
+    /// </returns>
+    public Task<GetPersonDetailsResponse> GetPersonDetails(GetPersonDetailsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets mentions of a person.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the person mentions.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved person mentions.
+    /// </returns>
+    public Task<GetPersonMentionsResponse> GetPersonMentions(GetPersonMentionsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a post.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved post.
+    /// </returns>
+    public Task<GetPostResponse> GetPost(GetPostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets posts.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving posts.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved posts.
+    /// </returns>
+    public Task<GetPostsResponse> GetPosts(GetPostsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets private messages.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving private messages.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved private messages.
+    /// </returns>
+    public Task<PrivateMessagesResponse> GetPrivateMessages(GetPrivateMessagesForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets replies.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving replies.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved replies.
+    /// </returns>
+    public Task<GetRepliesResponse> GetReplies(GetRepliesForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the count of reports.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the report count.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved report count.
+    /// </returns>
+    public Task<GetReportCountResponse> GetReportCount(GetReportCountForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets a site.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving a site.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved site.
+    /// </returns>
+    public Task<GetSiteResponse> GetSite(GetSiteForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets site metadata.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving site metadata.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved site metadata.
+    /// </returns>
+    public Task<GetSiteMetadataResponse> GetSiteMetadata(GetSiteMetadataForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the count of unread messages.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the unread count.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved unread count.
+    /// </returns>
+    public Task<GetUnreadCountResponse> GetUnreadCount(GetUnreadCountForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Gets the count of unread registration applications.
+    /// </summary>
+    /// <param name="form">The form to send for retrieving the unread registration application count.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the retrieved unread registration application count.
+    /// </returns>
+    public Task<GetUnreadRegistrationApplicationCountResponse> GetUnreadRegistrationApplicationCount(
+        GetUnreadRegistrationApplicationCountForm form,
+        CancellationToken cancellationToken
+    );
+
+    /// <summary>
+    /// Leaves admin role.
+    /// </summary>
+    /// <param name="form">The form to send for leaving the admin role.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after leaving the admin role.
+    /// </returns>
+    public Task<GetSiteResponse> LeaveAdmin(LeaveAdminForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Likes a comment.
+    /// </summary>
+    /// <param name="form">The form to send for liking a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after liking the comment.
+    /// </returns>
+    public Task<CommentResponse> LikeComment(LikeCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Likes a post.
+    /// </summary>
+    /// <param name="form">The form to send for liking a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after liking the post.
+    /// </returns>
+    public Task<PostResponse> LikePost(LikePostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists comment reports.
+    /// </summary>
+    /// <param name="form">The form to send for listing comment reports.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the listed comment reports.
+    /// </returns>
+    public Task<ListCommentReportsResponse> ListCommentReports(ListCommentReportsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists communities.
+    /// </summary>
+    /// <param name="form">The form to send for listing communities.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the listed communities.
+    /// </returns>
+    public Task<ListCommunitiesResponse> ListCommunities(ListCommunitiesForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists post reports.
+    /// </summary>
+    /// <param name="form">The form to send for listing post reports.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the listed post reports.
+    /// </returns>
+    public Task<ListPostReportsResponse> ListPostReports(ListPostReportsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists private message reports.
+    /// </summary>
+    /// <param name="form">The form to send for listing private message reports.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the listed private message reports.
+    /// </returns>
+    public Task<ListPrivateMessageReportsResponse> ListPrivateMessageReports(ListPrivateMessageReportsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lists registration applications.
+    /// </summary>
+    /// <param name="form">The form to send for listing registration applications.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response with the listed registration applications.
+    /// </returns>
+    public Task<ListRegistrationApplicationsResponse> ListRegistrationApplications(ListRegistrationApplicationsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Locks a post.
+    /// </summary>
+    /// <param name="form">The form to send for locking a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after locking the post.
+    /// </returns>
+    public Task<PostResponse> LockPost(LockPostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Performs login.
+    /// </summary>
+    /// <param name="form">The form to send for performing login.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after performing login.
+    /// </returns>
+    public Task<LoginResponse> Login(LoginForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks everything as read.
+    /// </summary>
+    /// <param name="form">The form to send for marking all replies as read.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after marking all replies as read.
+    /// </returns>
+    public Task<GetRepliesResponse> MarkAllAsRead(MarkAllAsReadForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks a comment reply as read.
+    /// </summary>
+    /// <param name="form">The form to send for marking a comment reply as read.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after marking the comment reply as read.
+    /// </returns>
+    public Task<CommentResponse> MarkCommentReplyAsRead(MarkCommentReplyAsReadForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks a person mention as read.
+    /// </summary>
+    /// <param name="form">The form to send for marking a person mention as read.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after marking the person mention as read.
+    /// </returns>
+    public Task<PersonMentionResponse> MarkPersonMentionAsRead(MarkPersonMentionAsReadForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks a post as read.
+    /// </summary>
+    /// <param name="form">The form to send for marking a post as read.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after marking the post as read.
+    /// </returns>
+    public Task<PostResponse> MarkPostAsRead(MarkPostAsReadForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marks a private message as read.
+    /// </summary>
+    /// <param name="form">The form to send for marking a private message as read.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after marking the private message as read.
+    /// </returns>
+    public Task<PrivateMessageResponse> MarkPrivateMessageAsRead(MarkPrivateMessageAsReadForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Performs a password change.
+    /// </summary>
+    /// <param name="form">The form to send for performing a password change.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after performing the password change.
+    /// </returns>
+    public Task<LoginResponse> PasswordChange(PasswordChangeForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Performs a password reset.
+    /// </summary>
+    /// <param name="form">The form to send for performing a password reset.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after performing the password reset.
+    /// </returns>
+    public Task<PasswordResetResponse> PasswordReset(PasswordResetForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Purges a comment.
+    /// </summary>
+    /// <param name="form">The form to send for purging a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after purging the comment.
+    /// </returns>
+    public Task<PurgeItemResponse> PurgeComment(PurgeCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Purges a community.
+    /// </summary>
+    /// <param name="form">The form to send for purging a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after purging the community.
+    /// </returns>
+    public Task<PurgeItemResponse> PurgeCommunity(PurgeCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Purges a person.
+    /// </summary>
+    /// <param name="form">The form to send for purging a person.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after purging the person.
+    /// </returns>
+    public Task<PurgeItemResponse> PurgePerson(PurgePersonForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Purges a post.
+    /// </summary>
+    /// <param name="form">The form to send for purging a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after purging the post.
+    /// </returns>
+    public Task<PurgeItemResponse> PurgePost(PurgePostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Registers a new account.
+    /// </summary>
+    /// <param name="form">The form to send for registering a new account.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after registering the account.
+    /// </returns>
+    public Task<LoginResponse> Register(RegisterForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Removes a comment.
+    /// </summary>
+    /// <param name="form">The form to send for removing a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after removing the comment.
+    /// </returns>
+    public Task<CommentResponse> RemoveComment(RemoveCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Removes a community.
+    /// </summary>
+    /// <param name="form">The form to send for removing a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after removing the community.
+    /// </returns>
+    public Task<CommunityResponse> RemoveCommunity(RemoveCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves a comment report.
+    /// </summary>
+    /// <param name="form">The form to send for resolving a comment report.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after resolving the comment report.
+    /// </returns>
+    public Task<CommentReportResponse> ResolveCommentReport(ResolveCommentReportForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves an object.
+    /// </summary>
+    /// <param name="form">The form to send for resolving an object.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after resolving the object.
+    /// </returns>
+    public Task<ResolveObjectResponse> ResolveObject(ResolveObjectForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves a post report.
+    /// </summary>
+    /// <param name="form">The form to send for resolving a post report.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after resolving the post report.
+    /// </returns>
+    public Task<PostReportResponse> ResolvePostReport(ResolvePostReportForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves a private message report.
+    /// </summary>
+    /// <param name="form">The form to send for resolving a private message report.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after resolving the private message report.
+    /// </returns>
+    public Task<PrivateMessageReportResponse> ResolvePrivateMessageReport(ResolvePrivateMessageReportForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Saves a comment.
+    /// </summary>
+    /// <param name="form">The form to send for saving a comment.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after saving the comment.
+    /// </returns>
+    public Task<CommentResponse> SaveComment(SaveCommentForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Saves a post.
+    /// </summary>
+    /// <param name="form">The form to send for saving a post.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after saving the post.
+    /// </returns>
+    public Task<PostResponse> SavePost(SavePostForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Saves user settings.
+    /// </summary>
+    /// <param name="form">The form to send for saving user settings.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after saving the user settings.
+    /// </returns>
+    public Task<LoginResponse> SaveUserSettings(SaveUserSettingsForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Performs a search.
+    /// </summary>
+    /// <param name="form">The form to send for performing a search.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after performing the search.
+    /// </returns>
+    public Task<SearchResponse> Search(SearchForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Transfers a community to another moderator.
+    /// </summary>
+    /// <param name="form">The form to send for transferring a community.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after transferring the community.
+    /// </returns>
+    public Task<GetCommunityResponse> TransferCommunity(TransferCommunityForm form, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifies an email for log in.
+    /// </summary>
+    /// <param name="form">The form to send for verifying an email.</param>
+    /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
+    /// <returns>
+    /// The task object representing the asynchronous operation. The task result contains the response after verifying the email.
+    /// </returns>
+    public Task<VerifyEmailResponse> VerifyEmail(VerifyEmailForm form, CancellationToken cancellationToken);
+}

--- a/dotNETLemmy.API/Types/Interfaces/ILemmyHttpClient.cs
+++ b/dotNETLemmy.API/Types/Interfaces/ILemmyHttpClient.cs
@@ -5,6 +5,8 @@ namespace dotNETLemmy.API.Types;
 
 public interface ILemmyHttpClient
 {
+    public string BaseAddress { get; set; }
+    
     /// <summary>
     ///     Sends an asynchronous HTTP request and returns the deserialized response.
     ///     <para>
@@ -15,7 +17,7 @@ public interface ILemmyHttpClient
     /// <param name="form">The form data to be sent, inherits <see cref="IForm" /></param>
     /// <param name="cancellationToken">Optional cancellation token to pass through to HttpClient</param>
     /// <returns>The deserialized response format</returns>
-    public Task<TResponse> SendAsync<TResponse>(IForm form, CancellationToken cancellationToken) where TResponse : Response, new();
+    public Task<TResponse> SendAsync<TResponse>(IForm form, CancellationToken cancellationToken = default) where TResponse : Response, new();
 
     /// <summary>
     ///     Adds an administrator.
@@ -26,7 +28,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after adding an
     ///     administrator.
     /// </returns>
-    public Task<AddAdminResponse> AddAdmin(AddAdminForm form, CancellationToken cancellationToken);
+    public Task<AddAdminResponse> AddAdmin(AddAdminForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Adds a moderator to a community.
@@ -37,7 +39,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after adding a
     ///     moderator to a community.
     /// </returns>
-    public Task<AddModToCommunityResponse> AddModToCommunity(AddModToCommunityForm form, CancellationToken cancellationToken);
+    public Task<AddModToCommunityResponse> AddModToCommunity(AddModToCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Approves a registration application.
@@ -48,7 +50,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after approving
     ///     a registration application.
     /// </returns>
-    public Task<ApproveRegistrationApplicationResponse> ApproveRegistrationApplication(ApproveRegistrationApplicationForm form, CancellationToken cancellationToken);
+    public Task<ApproveRegistrationApplicationResponse> ApproveRegistrationApplication(ApproveRegistrationApplicationForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Bans a person from a community.
@@ -59,7 +61,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after banning a
     ///     person from a community.
     /// </returns>
-    public Task<BanFromCommunityResponse> BanFromCommunity(BanFromCommunityForm form, CancellationToken cancellationToken);
+    public Task<BanFromCommunityResponse> BanFromCommunity(BanFromCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Bans a person.
@@ -70,7 +72,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after banning a
     ///     person.
     /// </returns>
-    public Task<BanPersonResponse> BanPerson(BanPersonForm form, CancellationToken cancellationToken);
+    public Task<BanPersonResponse> BanPerson(BanPersonForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Blocks a community.
@@ -81,7 +83,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after blocking
     ///     a community.
     /// </returns>
-    public Task<BlockCommunityResponse> BlockCommunity(BlockCommunityForm form, CancellationToken cancellationToken);
+    public Task<BlockCommunityResponse> BlockCommunity(BlockCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Blocks a person.
@@ -92,7 +94,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after blocking
     ///     a person.
     /// </returns>
-    public Task<BlockPersonResponse> BlockPerson(BlockPersonForm form, CancellationToken cancellationToken);
+    public Task<BlockPersonResponse> BlockPerson(BlockPersonForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Changes the password for the current user.
@@ -103,7 +105,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after changing
     ///     the password. <see cref="LoginResponse" />
     /// </returns>
-    public Task<LoginResponse> ChangePassword(ChangePasswordForm form, CancellationToken cancellationToken);
+    public Task<LoginResponse> ChangePassword(ChangePasswordForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new comment.
@@ -114,7 +116,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a comment. <see cref="CommentResponse" />
     /// </returns>
-    public Task<CommentResponse> CreateComment(CreateCommentForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> CreateComment(CreateCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new community.
@@ -125,7 +127,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a community.
     /// </returns>
-    public Task<CommunityResponse> CreateCommunity(CreateCommunityForm form, CancellationToken cancellationToken);
+    public Task<CommunityResponse> CreateCommunity(CreateCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new post.
@@ -136,7 +138,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a post.
     /// </returns>
-    public Task<PostResponse> CreatePost(CreatePostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> CreatePost(CreatePostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new report for a post.
@@ -147,7 +149,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a post report.
     /// </returns>
-    public Task<PostReportResponse> CreatePostReport(CreatePostReportForm form, CancellationToken cancellationToken);
+    public Task<PostReportResponse> CreatePostReport(CreatePostReportForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new private message.
@@ -158,7 +160,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a private message.
     /// </returns>
-    public Task<PrivateMessageResponse> CreatePrivateMessage(CreatePrivateMessageForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessageResponse> CreatePrivateMessage(CreatePrivateMessageForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new report for a private message.
@@ -169,7 +171,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a private message report.
     /// </returns>
-    public Task<PrivateMessageReportResponse> CreatePrivateMessageReport(CreatePrivateMessageReportForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessageReportResponse> CreatePrivateMessageReport(CreatePrivateMessageReportForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Creates a new report for a private message.
@@ -180,7 +182,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after creating
     ///     a private message report.
     /// </returns>
-    public Task<SiteResponse> CreateSite(CreateSiteForm form, CancellationToken cancellationToken);
+    public Task<SiteResponse> CreateSite(CreateSiteForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Deletes a user account.
@@ -191,7 +193,7 @@ public interface ILemmyHttpClient
     ///     The task object representing the asynchronous operation. The task result contains the response after deleting
     ///     a user account.
     /// </returns>
-    public Task<DeleteAccountResponse> DeleteAccount(DeleteAccountForm form, CancellationToken cancellationToken);
+    public Task<DeleteAccountResponse> DeleteAccount(DeleteAccountForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a comment.
@@ -201,7 +203,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after deleting the comment.
     /// </returns>
-    public Task<CommentResponse> DeleteComment(DeleteCommentForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> DeleteComment(DeleteCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a community.
@@ -211,7 +213,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after deleting the community.
     /// </returns>
-    public Task<CommunityResponse> DeleteCommunity(DeleteCommunityForm form, CancellationToken cancellationToken);
+    public Task<CommunityResponse> DeleteCommunity(DeleteCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a post.
@@ -221,7 +223,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after deleting the post.
     /// </returns>
-    public Task<PostResponse> DeletePost(DeletePostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> DeletePost(DeletePostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Deletes a private message.
@@ -231,7 +233,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after deleting the private message.
     /// </returns>
-    public Task<PrivateMessageResponse> DeletePrivateMessage(DeletePrivateMessageForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessageResponse> DeletePrivateMessage(DeletePrivateMessageForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Edits a comment.
@@ -241,7 +243,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after editing the comment.
     /// </returns>
-    public Task<CommentResponse> EditComment(EditCommentForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> EditComment(EditCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Edits a community.
@@ -251,7 +253,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after editing the community.
     /// </returns>
-    public Task<CommunityResponse> EditCommunity(EditCommunityForm form, CancellationToken cancellationToken);
+    public Task<CommunityResponse> EditCommunity(EditCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Edits a post.
@@ -261,7 +263,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after editing the post.
     /// </returns>
-    public Task<PostResponse> EditPost(EditPostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> EditPost(EditPostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Edits a private message.
@@ -271,7 +273,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after editing the private message.
     /// </returns>
-    public Task<PrivateMessageResponse> EditPrivateMessage(EditPrivateMessageForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessageResponse> EditPrivateMessage(EditPrivateMessageForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Edits a site.
@@ -281,7 +283,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after editing the site.
     /// </returns>
-    public Task<SiteResponse> EditSite(EditSiteForm form, CancellationToken cancellationToken);
+    public Task<SiteResponse> EditSite(EditSiteForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Features a post.
@@ -291,7 +293,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after featuring the post.
     /// </returns>
-    public Task<PostResponse> FeaturePost(FeaturePostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> FeaturePost(FeaturePostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Follows a community.
@@ -301,7 +303,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after following the community.
     /// </returns>
-    public Task<CommunityResponse> FollowCommunity(FollowCommunityForm form, CancellationToken cancellationToken);
+    public Task<CommunityResponse> FollowCommunity(FollowCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the list of banned persons.
@@ -311,7 +313,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the list of banned persons.
     /// </returns>
-    public Task<BannedPersonsResponse> GetBannedPersons(GetBannedPersonsForm form, CancellationToken cancellationToken);
+    public Task<BannedPersonsResponse> GetBannedPersons(GetBannedPersonsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a captcha.
@@ -321,7 +323,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved captcha.
     /// </returns>
-    public Task<GetCaptchaResponse> GetCaptcha(GetCaptchaForm form, CancellationToken cancellationToken);
+    public Task<GetCaptchaResponse> GetCaptcha(GetCaptchaForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets comments.
@@ -331,7 +333,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved comments.
     /// </returns>
-    public Task<GetCommentsResponse> GetComments(GetCommentsForm form, CancellationToken cancellationToken);
+    public Task<GetCommentsResponse> GetComments(GetCommentsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a community.
@@ -341,7 +343,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved community.
     /// </returns>
-    public Task<GetCommunityResponse> GetCommunity(GetCommunityForm form, CancellationToken cancellationToken);
+    public Task<GetCommunityResponse> GetCommunity(GetCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the modlog.
@@ -351,7 +353,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved modlog.
     /// </returns>
-    public Task<GetModlogResponse> GetModlog(GetModlogForm form, CancellationToken cancellationToken);
+    public Task<GetModlogResponse> GetModlog(GetModlogForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the details of a person.
@@ -361,7 +363,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved person details.
     /// </returns>
-    public Task<GetPersonDetailsResponse> GetPersonDetails(GetPersonDetailsForm form, CancellationToken cancellationToken);
+    public Task<GetPersonDetailsResponse> GetPersonDetails(GetPersonDetailsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets mentions of a person.
@@ -371,7 +373,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved person mentions.
     /// </returns>
-    public Task<GetPersonMentionsResponse> GetPersonMentions(GetPersonMentionsForm form, CancellationToken cancellationToken);
+    public Task<GetPersonMentionsResponse> GetPersonMentions(GetPersonMentionsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a post.
@@ -381,7 +383,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved post.
     /// </returns>
-    public Task<GetPostResponse> GetPost(GetPostForm form, CancellationToken cancellationToken);
+    public Task<GetPostResponse> GetPost(GetPostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets posts.
@@ -391,7 +393,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved posts.
     /// </returns>
-    public Task<GetPostsResponse> GetPosts(GetPostsForm form, CancellationToken cancellationToken);
+    public Task<GetPostsResponse> GetPosts(GetPostsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets private messages.
@@ -401,7 +403,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved private messages.
     /// </returns>
-    public Task<PrivateMessagesResponse> GetPrivateMessages(GetPrivateMessagesForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessagesResponse> GetPrivateMessages(GetPrivateMessagesForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets replies.
@@ -411,7 +413,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved replies.
     /// </returns>
-    public Task<GetRepliesResponse> GetReplies(GetRepliesForm form, CancellationToken cancellationToken);
+    public Task<GetRepliesResponse> GetReplies(GetRepliesForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the count of reports.
@@ -421,7 +423,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved report count.
     /// </returns>
-    public Task<GetReportCountResponse> GetReportCount(GetReportCountForm form, CancellationToken cancellationToken);
+    public Task<GetReportCountResponse> GetReportCount(GetReportCountForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a site.
@@ -431,7 +433,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved site.
     /// </returns>
-    public Task<GetSiteResponse> GetSite(GetSiteForm form, CancellationToken cancellationToken);
+    public Task<GetSiteResponse> GetSite(GetSiteForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets site metadata.
@@ -441,7 +443,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved site metadata.
     /// </returns>
-    public Task<GetSiteMetadataResponse> GetSiteMetadata(GetSiteMetadataForm form, CancellationToken cancellationToken);
+    public Task<GetSiteMetadataResponse> GetSiteMetadata(GetSiteMetadataForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the count of unread messages.
@@ -451,7 +453,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the retrieved unread count.
     /// </returns>
-    public Task<GetUnreadCountResponse> GetUnreadCount(GetUnreadCountForm form, CancellationToken cancellationToken);
+    public Task<GetUnreadCountResponse> GetUnreadCount(GetUnreadCountForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the count of unread registration applications.
@@ -474,7 +476,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after leaving the admin role.
     /// </returns>
-    public Task<GetSiteResponse> LeaveAdmin(LeaveAdminForm form, CancellationToken cancellationToken);
+    public Task<GetSiteResponse> LeaveAdmin(LeaveAdminForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Likes a comment.
@@ -484,7 +486,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after liking the comment.
     /// </returns>
-    public Task<CommentResponse> LikeComment(LikeCommentForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> LikeComment(LikeCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Likes a post.
@@ -494,7 +496,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after liking the post.
     /// </returns>
-    public Task<PostResponse> LikePost(LikePostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> LikePost(LikePostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists comment reports.
@@ -504,7 +506,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the listed comment reports.
     /// </returns>
-    public Task<ListCommentReportsResponse> ListCommentReports(ListCommentReportsForm form, CancellationToken cancellationToken);
+    public Task<ListCommentReportsResponse> ListCommentReports(ListCommentReportsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists communities.
@@ -514,7 +516,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the listed communities.
     /// </returns>
-    public Task<ListCommunitiesResponse> ListCommunities(ListCommunitiesForm form, CancellationToken cancellationToken);
+    public Task<ListCommunitiesResponse> ListCommunities(ListCommunitiesForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists post reports.
@@ -524,7 +526,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the listed post reports.
     /// </returns>
-    public Task<ListPostReportsResponse> ListPostReports(ListPostReportsForm form, CancellationToken cancellationToken);
+    public Task<ListPostReportsResponse> ListPostReports(ListPostReportsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists private message reports.
@@ -534,7 +536,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the listed private message reports.
     /// </returns>
-    public Task<ListPrivateMessageReportsResponse> ListPrivateMessageReports(ListPrivateMessageReportsForm form, CancellationToken cancellationToken);
+    public Task<ListPrivateMessageReportsResponse> ListPrivateMessageReports(ListPrivateMessageReportsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Lists registration applications.
@@ -544,7 +546,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response with the listed registration applications.
     /// </returns>
-    public Task<ListRegistrationApplicationsResponse> ListRegistrationApplications(ListRegistrationApplicationsForm form, CancellationToken cancellationToken);
+    public Task<ListRegistrationApplicationsResponse> ListRegistrationApplications(ListRegistrationApplicationsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Locks a post.
@@ -554,7 +556,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after locking the post.
     /// </returns>
-    public Task<PostResponse> LockPost(LockPostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> LockPost(LockPostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Performs login.
@@ -564,7 +566,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after performing login.
     /// </returns>
-    public Task<LoginResponse> Login(LoginForm form, CancellationToken cancellationToken);
+    public Task<LoginResponse> Login(LoginForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks everything as read.
@@ -574,7 +576,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after marking all replies as read.
     /// </returns>
-    public Task<GetRepliesResponse> MarkAllAsRead(MarkAllAsReadForm form, CancellationToken cancellationToken);
+    public Task<GetRepliesResponse> MarkAllAsRead(MarkAllAsReadForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks a comment reply as read.
@@ -584,7 +586,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after marking the comment reply as read.
     /// </returns>
-    public Task<CommentResponse> MarkCommentReplyAsRead(MarkCommentReplyAsReadForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> MarkCommentReplyAsRead(MarkCommentReplyAsReadForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks a person mention as read.
@@ -594,7 +596,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after marking the person mention as read.
     /// </returns>
-    public Task<PersonMentionResponse> MarkPersonMentionAsRead(MarkPersonMentionAsReadForm form, CancellationToken cancellationToken);
+    public Task<PersonMentionResponse> MarkPersonMentionAsRead(MarkPersonMentionAsReadForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks a post as read.
@@ -604,7 +606,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after marking the post as read.
     /// </returns>
-    public Task<PostResponse> MarkPostAsRead(MarkPostAsReadForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> MarkPostAsRead(MarkPostAsReadForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Marks a private message as read.
@@ -614,7 +616,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after marking the private message as read.
     /// </returns>
-    public Task<PrivateMessageResponse> MarkPrivateMessageAsRead(MarkPrivateMessageAsReadForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessageResponse> MarkPrivateMessageAsRead(MarkPrivateMessageAsReadForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Performs a password change.
@@ -624,7 +626,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after performing the password change.
     /// </returns>
-    public Task<LoginResponse> PasswordChange(PasswordChangeForm form, CancellationToken cancellationToken);
+    public Task<LoginResponse> PasswordChange(PasswordChangeForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Performs a password reset.
@@ -634,7 +636,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after performing the password reset.
     /// </returns>
-    public Task<PasswordResetResponse> PasswordReset(PasswordResetForm form, CancellationToken cancellationToken);
+    public Task<PasswordResetResponse> PasswordReset(PasswordResetForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purges a comment.
@@ -644,7 +646,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after purging the comment.
     /// </returns>
-    public Task<PurgeItemResponse> PurgeComment(PurgeCommentForm form, CancellationToken cancellationToken);
+    public Task<PurgeItemResponse> PurgeComment(PurgeCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purges a community.
@@ -654,7 +656,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after purging the community.
     /// </returns>
-    public Task<PurgeItemResponse> PurgeCommunity(PurgeCommunityForm form, CancellationToken cancellationToken);
+    public Task<PurgeItemResponse> PurgeCommunity(PurgeCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purges a person.
@@ -664,7 +666,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after purging the person.
     /// </returns>
-    public Task<PurgeItemResponse> PurgePerson(PurgePersonForm form, CancellationToken cancellationToken);
+    public Task<PurgeItemResponse> PurgePerson(PurgePersonForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Purges a post.
@@ -674,7 +676,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after purging the post.
     /// </returns>
-    public Task<PurgeItemResponse> PurgePost(PurgePostForm form, CancellationToken cancellationToken);
+    public Task<PurgeItemResponse> PurgePost(PurgePostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Registers a new account.
@@ -684,7 +686,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after registering the account.
     /// </returns>
-    public Task<LoginResponse> Register(RegisterForm form, CancellationToken cancellationToken);
+    public Task<LoginResponse> Register(RegisterForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes a comment.
@@ -694,7 +696,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after removing the comment.
     /// </returns>
-    public Task<CommentResponse> RemoveComment(RemoveCommentForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> RemoveComment(RemoveCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes a community.
@@ -704,7 +706,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after removing the community.
     /// </returns>
-    public Task<CommunityResponse> RemoveCommunity(RemoveCommunityForm form, CancellationToken cancellationToken);
+    public Task<CommunityResponse> RemoveCommunity(RemoveCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Resolves a comment report.
@@ -714,7 +716,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after resolving the comment report.
     /// </returns>
-    public Task<CommentReportResponse> ResolveCommentReport(ResolveCommentReportForm form, CancellationToken cancellationToken);
+    public Task<CommentReportResponse> ResolveCommentReport(ResolveCommentReportForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Resolves an object.
@@ -724,7 +726,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after resolving the object.
     /// </returns>
-    public Task<ResolveObjectResponse> ResolveObject(ResolveObjectForm form, CancellationToken cancellationToken);
+    public Task<ResolveObjectResponse> ResolveObject(ResolveObjectForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Resolves a post report.
@@ -734,7 +736,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after resolving the post report.
     /// </returns>
-    public Task<PostReportResponse> ResolvePostReport(ResolvePostReportForm form, CancellationToken cancellationToken);
+    public Task<PostReportResponse> ResolvePostReport(ResolvePostReportForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Resolves a private message report.
@@ -744,7 +746,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after resolving the private message report.
     /// </returns>
-    public Task<PrivateMessageReportResponse> ResolvePrivateMessageReport(ResolvePrivateMessageReportForm form, CancellationToken cancellationToken);
+    public Task<PrivateMessageReportResponse> ResolvePrivateMessageReport(ResolvePrivateMessageReportForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Saves a comment.
@@ -754,7 +756,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after saving the comment.
     /// </returns>
-    public Task<CommentResponse> SaveComment(SaveCommentForm form, CancellationToken cancellationToken);
+    public Task<CommentResponse> SaveComment(SaveCommentForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Saves a post.
@@ -764,7 +766,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after saving the post.
     /// </returns>
-    public Task<PostResponse> SavePost(SavePostForm form, CancellationToken cancellationToken);
+    public Task<PostResponse> SavePost(SavePostForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Saves user settings.
@@ -774,7 +776,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after saving the user settings.
     /// </returns>
-    public Task<LoginResponse> SaveUserSettings(SaveUserSettingsForm form, CancellationToken cancellationToken);
+    public Task<LoginResponse> SaveUserSettings(SaveUserSettingsForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Performs a search.
@@ -784,7 +786,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after performing the search.
     /// </returns>
-    public Task<SearchResponse> Search(SearchForm form, CancellationToken cancellationToken);
+    public Task<SearchResponse> Search(SearchForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Transfers a community to another moderator.
@@ -794,7 +796,7 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after transferring the community.
     /// </returns>
-    public Task<GetCommunityResponse> TransferCommunity(TransferCommunityForm form, CancellationToken cancellationToken);
+    public Task<GetCommunityResponse> TransferCommunity(TransferCommunityForm form, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Verifies an email for log in.
@@ -804,5 +806,5 @@ public interface ILemmyHttpClient
     /// <returns>
     /// The task object representing the asynchronous operation. The task result contains the response after verifying the email.
     /// </returns>
-    public Task<VerifyEmailResponse> VerifyEmail(VerifyEmailForm form, CancellationToken cancellationToken);
+    public Task<VerifyEmailResponse> VerifyEmail(VerifyEmailForm form, CancellationToken cancellationToken = default);
 }

--- a/dotNETLemmy.API/dotNETLemmy.API.csproj
+++ b/dotNETLemmy.API/dotNETLemmy.API.csproj
@@ -20,6 +20,7 @@
     </PropertyGroup>
     
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0-preview.5.23280.8" />
         <PackageReference Include="MinVer" Version="5.0.0-alpha.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotNETLemmy.Docs/api/index.md
+++ b/dotNETLemmy.Docs/api/index.md
@@ -16,7 +16,7 @@ public class NonstandardForm : IForm
     [JsonProperty(PropertyName = "NonStandardExample")]
     public int ExampleInt { get; set; } // serialized as NonStandardExample
     
-    public string EndPoint => "/nonstandard/api/endpoint"
+    public string EndPoint => "/api/v3/nonstandard/api/endpoint"
     public HttpMethod Method => HttpMethod.Post; // Substitute for correct request method
 }
 ```

--- a/dotNETLemmy.Docs/index.md
+++ b/dotNETLemmy.Docs/index.md
@@ -5,20 +5,50 @@
 An implementation of the Lemmy HTTP API modeled after [lemmy-js-client](https://github.com/LemmyNet/lemmy-js-client).
 
 ## Usage
-[LemmyHttpClient Docs](xref:dotNETLemmy.API.LemmyHttpClient)
+The [LemmyHttpClient](xref:dotNETLemmy.API.LemmyHttpClient) class has a constructor which takes an [HttpClient](https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-7.0) as a parameter, allowing for it to be used as a typed [IHttpClientFactory](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-7.0) client with dependency injection.
 
+`Program.cs:`
 ```csharp
-// Logs into lemmy.ml and stores the authentication token to be used for further requests
-var lemmyClient = new LemmyHttpClient("https://lemmy.ml");
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
-var loginForm = new LoginForm {
-    UsernameOrEmail = "username",
-    Password = "password"
+builder.Services.AddHostedService<LemmyWorker>(provider => 
+    new LemmyWorker(provider.GetRequiredService<ILemmyHttpClient>())
+    {
+        BaseAddress = "https://enterprise.lemmy.ml/"
+    });
+builder.Services.AddHttpClient<ILemmyHttpClient, LemmyHttpClient>();
+
+IHost host = builder.Build();
+
+host.Run();
+```
+
+`LemmyWorker.cs:`
+```csharp
+// Logs getPostResponse every 10 seconds
+public class LemmyWorker : BackgroundService
+{
+    public string BaseAddress
+    {
+        get => _lemmyHttpClient.BaseAddress;
+        set => _lemmyHttpClient.BaseAddress = value;
+    }
+    
+    private readonly ILemmyHttpClient _lemmyHttpClient;
+
+    public LemmyWorker(ILemmyHttpClient lemmyHttpClient) =>
+        _lemmyHttpClient = lemmyHttpClient;
+    
+    protected override async Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        while(!cancellationToken.IsCancellationRequested)
+        {
+            GetPostsResponse getPostsResponse = await _lemmyHttpClient.GetPosts(new GetPostsForm(), cancellationToken);
+            Console.WriteLine(getPostsResponse);
+            await Task.Delay(10000, cancellationToken);
+        }
+    }
 }
-
-LoginResponse loginResponse = await lemmyClient.Login(loginForm);
-
-if(loginResponse.Jwt is not string auth) throw new Exception("Login Failed");
 ```
 
 </div>

--- a/dotNETLemmy.Tests/Tests.cs
+++ b/dotNETLemmy.Tests/Tests.cs
@@ -16,10 +16,10 @@ public class Tests
     private readonly string _password = Environment.GetEnvironmentVariable("LEMMY_PASS") ?? "";
     private readonly string _lemmyurl = Environment.GetEnvironmentVariable("LEMMY_URL") ?? "";
 
-    private LemmyHttpClient GetDefaultClient()
+    private ILemmyHttpClient GetDefaultClient()
     {
         Assert.That(_host, Is.Not.Null);
-        var client = _host!.Services.GetService<LemmyHttpClient>();
+        var client = _host!.Services.GetService<ILemmyHttpClient>();
         Assert.That(client, Is.Not.Null);
         return client!;
     }
@@ -27,18 +27,11 @@ public class Tests
     [OneTimeSetUp]
     public void Init()
     {
-        Assert.That(_lemmyurl, Is.Not.Empty);
-        
         // Configure default client
-        var builder = Host.CreateDefaultBuilder()
-            .ConfigureServices(services =>
-            {
-                services.AddHttpClient<LemmyHttpClient>()
-                    .ConfigureHttpClient(client =>
-                    {
-                        client.BaseAddress = new Uri(_lemmyurl);
-                    });
-            });
+        Assert.That(_lemmyurl, Is.Not.Empty);
+        var builder = Host.CreateApplicationBuilder();
+        builder.Services.AddHttpClient<ILemmyHttpClient, LemmyHttpClient>()
+            .ConfigureHttpClient(client => client.BaseAddress = new Uri(_lemmyurl));
         _host = builder.Build();
     }
 

--- a/dotNETLemmy.Tests/dotNETLemmy.Tests.csproj
+++ b/dotNETLemmy.Tests/dotNETLemmy.Tests.csproj
@@ -12,6 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0-preview.5.23280.8" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0-preview.5.23280.8" />
+        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0-preview.5.23280.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />

--- a/dotNETLemmy.sln.DotSettings
+++ b/dotNETLemmy.sln.DotSettings
@@ -1,5 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Downvotes/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lemmyurl/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Modlog/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Necro/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Notifs/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
LemmyHttpClient constructor is now implemented taking an HttpClient in as a parameter, allowing for it to be used as a [Typed Client](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-7.0#typed-clients)